### PR TITLE
Use feature macros 

### DIFF
--- a/src/date/date.h
+++ b/src/date/date.h
@@ -33,7 +33,10 @@
 // We did not mean to shout.
 
 #ifndef HAS_STRING_VIEW
-#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#  if __has_include(<string_view>)
+#    include <string_view>
+#  endif
+#  ifdef __cpp_lib_string_view
 #    define HAS_STRING_VIEW 1
 #  else
 #    define HAS_STRING_VIEW 0
@@ -61,9 +64,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#if HAS_STRING_VIEW
-# include <string_view>
-#endif
 #include <utility>
 #include <type_traits>
 

--- a/src/date/date.h
+++ b/src/date/date.h
@@ -136,7 +136,7 @@ namespace date
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#  ifdef __cpp_lib_uncaught_exceptions
 #    define HAS_UNCAUGHT_EXCEPTIONS 1
 #  else
 #    define HAS_UNCAUGHT_EXCEPTIONS 0

--- a/src/date/tz.h
+++ b/src/date/tz.h
@@ -89,7 +89,7 @@ static_assert(HAS_REMOTE_API == 0 ? AUTO_DOWNLOAD == 0 : true,
 #endif
 
 #ifndef HAS_DEDUCTION_GUIDES
-#  if __cplusplus >= 201703
+#  ifdef __cpp_deduction_guides
 #    define HAS_DEDUCTION_GUIDES 1
 #  else
 #    define HAS_DEDUCTION_GUIDES 0


### PR DESCRIPTION
Use feature macros and __has_include() to detect features as a best practice vs. hard-coding.