### PR TITLE
small changes

### DIFF
--- a/inst/duration.m
+++ b/inst/duration.m
@@ -34,7 +34,7 @@ classdef duration
   ## functions are also available as methods of @code{duration} arrays to
   ## extract individual duration units as numeric arrays.
   ##
-  ## @seealso{calendarDuration, duration}
+  ## @seealso{calendarDuration, datetime}
   ## @end deftp
 
   properties


### PR DESCRIPTION
1.Base on page content,`See also`should connect with other functions.

2.```d = duration('01:30:45', 'InputFormat', 'hh:mm:ss');```
Due to the missing `;` in the code, the above code outputs:
```errmsg =          ```