### PR TITLE
Fix typos and logic errors in categorical, string, and struct2table

### DIFF
--- a/inst/categorical.m
+++ b/inst/categorical.m
@@ -761,7 +761,7 @@ classdef categorical
         return;
       endif
       if (numel (varargin) > 0)
-        if (! ismatrix (A) || ! ismatrix (B) || size (A, 2) != size (b, 2))
+        if (! ismatrix (A) || ! ismatrix (B) || size (A, 2) != size (B, 2))
           error (["categorical.ismember: cannot use 'rows' unless both", ...
                   " A and B are matrices with the same number of columns."]);
         endif

--- a/inst/duration.m
+++ b/inst/duration.m
@@ -686,7 +686,6 @@ classdef duration
       else
         error ("duration.isbetween: invalid INTERVALTYPE option.");
       endif
-      error ("duration.isequal: not implemented yet.");
     endfunction
 
     function TF = iscolumn (this)

--- a/inst/string.m
+++ b/inst/string.m
@@ -22,7 +22,7 @@ classdef string
   ## Array representing sequences of characters.
   ##
   ## A string array is an array, where each element stores a sequence of
-  ## characters of arbitraty length.
+  ## characters of arbitrary length.
   ##
   ## A string array can also have missing elements, which differ from a sequence
   ## of characters of zero length (the equivalent of an empty character vector).
@@ -467,7 +467,7 @@ classdef string
 ##                             Available Methods                              ##
 ##                                                                            ##
 ## 'contains'         'endsWith'         'matches'          'startsWith'      ##
-## 'iscolumm'         'isempty'          'ismatrix'         'ismember'        ##
+## 'iscolumn'         'isempty'          'ismatrix'         'ismember'        ##
 ## 'ismissing'        'isrow'            'isscalar'         'issorted'        ##
 ## 'isstring'         'isvector'                                              ##
 ##                                                                            ##
@@ -916,7 +916,7 @@ classdef string
       out = args{1};
       tmp = cellfun (@(obj) obj.strs, args, 'UniformOutput', false);
       out.strs = cat (dim, tmp{:});
-      tmp = cellfun (@(obj) obj.strs, args, 'UniformOutput', false);
+      tmp = cellfun (@(obj) obj.isMissing, args, 'UniformOutput', false);
       out.isMissing = cat (dim, tmp{:});
     endfunction
 

--- a/inst/struct2table.m
+++ b/inst/struct2table.m
@@ -102,7 +102,7 @@ function tbl = struct2table (S, varargin)
     endfor
     nrows = cellfun (@rows, varValues);
     if (! all (ismember (nrows, nrows(1))))
-      error ("struct2table: fiels have different rows. Use 'AsArray' option.");
+      error ("struct2table: fields have different rows. Use 'AsArray' option.");
     endif
   endif
 
@@ -161,7 +161,7 @@ endfunction
 %! assert (size (tbl.B{1}), [2, 1]);
 
 %!error<struct2table: input array must be a structure.> struct2table ({1});
-%!error<struct2table: fiels have different rows. Use 'AsArray' option.> ...
+%!error<struct2table: fields have different rows. Use 'AsArray' option.> ...
 %! struct2table (struct ('A', 1, 'B', [1; 2]));
 %!error<struct2table: 'RowNames' must match the rows in input cell.> ...
 %! struct2table (struct ('A', {'a';, 'b'}, 'B', [1; 2]), 'RowNames', 'q');


### PR DESCRIPTION
1.Corrected a variable name typo in categorical.m ismember. 
2.Removed an unwanted error line in duration.m.
3.Fixed spelling and method name typos in string.m. 
4.Corrected error messages in struct2table.m.