### PR TITLE
Fix spelling issue

### DIFF
--- a/src/__datetime__.cc
+++ b/src/__datetime__.cc
@@ -245,7 +245,7 @@ DEFUN_DLD(__datetime__, args, nargout,
  @deftypefnx {datatypes} {[@dots{}] =} __datetime__ (@dots{}, @qcode{'TimeZone'}, @var{tzone}, @qcode{'toTimeZone'}, @var{totzone})\n\
 \n\
 \n\
-Base fuction for datetime class. \n\
+Base function for datetime class. \n\
 \n\n\
 @end deftypefn")
 {


### PR DESCRIPTION
This is a very minor issue. It was detected by Lintian (the Debian package linter). I am planning to upload the octave-datatypes package to Debian unstable soon.