### PR TITLE
table: Fix function to use iscolumn instead of iscol

### DIFF
--- a/inst/table.m
+++ b/inst/table.m
@@ -4356,7 +4356,7 @@ classdef table
     ##
     ## @end deftypefn
     function TF = isvector (this)
-      TF = isrow (this) || iscol (this);
+      TF = isrow (this) || iscolumn (this);
     endfunction
 
     ## -*- texinfo -*-


### PR DESCRIPTION
iscol is undefined, the correct and defined function name is iscolumn.This fixes issue #23