### PR TITLE
datetime: fix `month` and `second`

### DIFF
--- a/inst/datetime.m
+++ b/inst/datetime.m
@@ -640,7 +640,7 @@ classdef datetime
 
     ## -*- texinfo -*-
     ## @deftypefn  {datetime} {@var{s} =} second (@var{T})
-    ## @deftypefnx {datetime} {@var{s} =} second (@var{T}, @var{dayType})
+    ## @deftypefnx {datetime} {@var{s} =} second (@var{T}, @var{secondType})
     ##
     ## Seconds component of a datetime array.
     ##
@@ -651,7 +651,7 @@ classdef datetime
     ## @var{T}.  Not-A-Time (@qcode{NaT}) values in @var{T} are returned as
     ## @qcode{NaN} in the output array.
     ##
-    ## @code{@var{D} = second (@var{T}, @var{secondType})} returns the seconds
+    ## @code{@var{s} = second (@var{T}, @var{secondType})} returns the seconds
     ## for each element of the input datetime array @var{T} as specified by
     ## @var{secondType}, which may have any of the following options:
     ##
@@ -663,8 +663,14 @@ classdef datetime
     ## @end itemize
     ##
     ## @end deftypefn
-    function out = second (this)
-      out = this.Second;
+    function out = second (this, secondType = 'secondofminute')
+      if (strcmpi (secondType, 'secondofminute'))
+        out = this.Second;
+      elseif (strcmpi (secondType, 'secondofday'))
+        out = this.Hour * 3600 + this.Minute * 60 + this.Second;
+      else
+        error ("datetime.second: unrecognized SECONDTYPE.");
+      endif
     endfunction
 
   endmethods


### PR DESCRIPTION
## datetime: month
Remove a line of code that may be an initial placeholder, as it would invalidate all previous executions and cause the month to be displayed in numeric form.

After modification, it can be executed normally as shown below.
```octave
octave:4> t=datetime('now')
t =
  datetime
   28-Feb-2026 23:44:23.682

octave:5> m = month(t, 'name')
m =
  1x1 cell array
    {'February'}

octave:6> m = month(t, 'shortname')
m =
  1x1 cell array
    {'Feb'}

octave:7> m2 = month(t)
m2 = 2
```
## datetime: second
Added the second parameter `secondType` as described in the texinfo documentation.