### PR TITLE
Generate hash keys consistently across systems with different endianness

### DIFF
--- a/inst/keyHash.m
+++ b/inst/keyHash.m
@@ -54,15 +54,18 @@ function key = keyHash (x = [], base = [])
     key = __ckeyHash__(init_str);
   endif
   ## Select data type
-  if (isnumeric (x) || islogical (x))
-    key = __nkeyHash__(x(:), key);
+  if (isnumeric (x))
+    x = num2hex (x)'(:)';
+  elseif (islogical (x))
+    x = num2hex (int8 (x))'(:)';
   elseif (ischar (x))
-    key = __ckeyHash__(x(:), key);
+    x = x(:);
   elseif (iscellstr (x))
-    key = __ckeyHash__([x{:}], key);
+    x = [x{:}];
   else
     error ("keyHash: unsupported input type.");
   endif
+  key = __ckeyHash__(x, key);
 endfunction
 
 %!test
@@ -97,10 +100,14 @@ endfunction
 %! assert (key, E);
 %!test
 %! A = uint64(128);
-%! E = uint64(8038837787959150693);
+%! E = uint64(16460521561820702077);
 %! key = keyHash (A);
 %! assert (isequal(key, E), sprintf("k: %lx e: %lx d: %lx", key, E, key - E));
 %! assert (key, E);
+%!test
+%!  A = keyHash ([1, 2; 3, 4]);
+%!  B = keyHash ([1; 3; 2; 4]);
+%!  assert (! isequal (A, B));
 
 %!error<Invalid call to keyHash.  Correct usage is:> keyHash ();
 %!error<keyHash: BASE must be a UINT64 scalar.> keyHash (1, 1);


### PR DESCRIPTION
The data content of the numeric or logical input objects in either the scalar or the matrix form is now “serialized”, with the underlying bytes been represented as a string in hexadecimal format. This representation is independent of the system's endianness and accounts for the full precision of the data, since every bit is represented.

The numeric or logical input object is transformed using the `num2hex` function, which yields a string as output. Therefore, the call to `__nkeyHash__` is replaced by a call to `__ckeyHash__`.

The downside of this change is that backward compatibility is lost for numeric and logical inputs. For this reason, the expected value for `keyHash(unit64(128))` in one of the unite tests has been adjusted.

An additional unit test has been added to ensure that two objects with the same internal byte representation, namely `[1,2;3,4]` and `[1;3;2;4]`, will yield different hash codes.

This change has been tested on both amd64 (little-endian) and s390x (big-endian) systems.