### PR TITLE
Improve src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,8 @@ else
 	LIBS =
 endif
 
+MKOCTFILE ?= mkoctfile
+
 LDFLAGS += $(LIBS)
 
 TZFLAGS = -DHAS_REMOTE_API=0

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,9 +13,17 @@ LDFLAGS += $(LIBS)
 
 TZFLAGS = -DHAS_REMOTE_API=0
 
-all:
-	$(MKOCTFILE)       '-I ./date'  __datetime__.cc tz.cpp $(TZFLAGS) $(LDFLAGS)
-	$(MKOCTFILE)       __table2csv__.cc $(LDFLAGS)
-	$(MKOCTFILE)       __csv2table__.cc $(LDFLAGS)
-	$(MKOCTFILE)       __ckeyHash__.cc $(LDFLAGS)
-	$(MKOCTFILE)       __nkeyHash__.cc $(LDFLAGS)
+OCTFILES = __datetime__.oct	\
+           __table2csv__.oct	\
+           __csv2table__.oct	\
+           __ckeyHash__.oct	\
+           __nkeyHash__.oct
+
+.PHONY: all
+all: $(OCTFILES)
+
+__datetime__.oct: __datetime__.cc tz.cpp
+	$(MKOCTFILE) '-I ./date'  __datetime__.cc tz.cpp $(TZFLAGS) $(LDFLAGS)
+
+%.oct: %.cc
+	$(MKOCTFILE) $< $(LDFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,3 +27,7 @@ __datetime__.oct: __datetime__.cc tz.cpp
 
 %.oct: %.cc
 	$(MKOCTFILE) $< $(LDFLAGS)
+
+.PHONY: clean
+clean:
+	rm -f $(OCTFILES)


### PR DESCRIPTION
This PR contains three commits that improve the `src/Makefile` file. You can cherry-pick the ones that seem appropriate (or none of them, if they are all inappropriate). The changes are:

- Set a default value for the variable `MKOCTFILE`, such that users do not have to specify it when running make: `make MKOCTFILE=mkoctfile`.
- Use a pattern rule for building the `.oct` files from the corresponding `.cc` files. This change means that mkoctfile is invoked for a specific `.oct` file only when the corresponding `.cc` file is modified.
- Add a rule for cleaning the directory.
